### PR TITLE
Misc fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python: [3.7, 3.8, 3.9]
+        python: ["3.9", "3.11"]
 
     steps:
       - uses: actions/checkout@v2

--- a/scripts/debug-sample.py
+++ b/scripts/debug-sample.py
@@ -1,0 +1,20 @@
+import napari
+from pathlib import Path
+
+
+viewer = napari.Viewer()
+
+dw, widget = viewer.window.add_plugin_dock_widget(
+        'annotrack', 'sample_from_csv'
+        )
+
+root = Path('/Users/jni/data/FindingAndFollowing/annotrack_example/')
+
+widget(viewer,
+       path_to_csv=root / 'annotrack_csvs/mini-sample-jni-ome.csv',
+       output_dir=root / 'out-annotrack2',
+       output_name='result',
+       n_samples=15,
+       )
+
+napari.run()

--- a/src/annotrack/_dock_widgets.py
+++ b/src/annotrack/_dock_widgets.py
@@ -164,7 +164,7 @@ def _sample_from_csv(
 
 
 @magic_factory(
-    path_to_csv={'widget_type': 'FileEdit'}, 
+    path_to_csv={'widget_type': 'FileEdit', 'mode': 'r'},
     output_dir={'widget_type': 'FileEdit', 'mode' : 'd'}, 
     scale={'widget_type' : 'LiteralEvalLineEdit'},
 )

--- a/src/annotrack/_dock_widgets.py
+++ b/src/annotrack/_dock_widgets.py
@@ -35,8 +35,8 @@ def sample_from_csv(
     ):
     """
     Sample track segments from CSV. This sampling works by randomly selecting
-    a vertex (object coordinate) from a trajectory, then selecting the vertexes
-    up to +/- floor(1/2 frames) frames wayy from the selected track vertex. If 
+    a vertex (object coordinate) from a trajectory, then selecting the vertices
+    up to +/- floor(1/2 frames) frames away from the selected track vertex. If
     the track does not extend this far, only the available track will be taken. 
     The 
 

--- a/src/annotrack/_dock_widgets.py
+++ b/src/annotrack/_dock_widgets.py
@@ -114,6 +114,8 @@ def _sample_from_csv(
         annotate_now: bool = True
     ):
 
+    path_to_csv = Path(path_to_csv)
+    output_dir = Path(output_dir)
     t_col = tzyx_cols[0]
     scale = (1, ) + scale
     instructions = pd.read_csv(path_to_csv)
@@ -153,7 +155,7 @@ def _sample_from_csv(
             row = instructions.loc[idx, :].copy()
             row['sample_path'] = sample_dir
             instructions = pd.concat([instructions, row]).reset_index()
-    instructions.to_csv(path_to_csv)  
+    instructions.to_csv(Path(sample_dir) / 'instructions.csv')
     
     # View
     # ----

--- a/src/annotrack/_dock_widgets.py
+++ b/src/annotrack/_dock_widgets.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import napari
 import zarr
 from magicgui import magic_factory
-from .sampling import sample_tracks, sample_tracks, get_sample_hypervolumes, save_sample
+from .sampling import sample_tracks, get_sample_hypervolumes, save_sample
 from .annotation import SampleViewer
 from .sample_management import prepare_sample_for_annotation
 from typing import Tuple, Union

--- a/src/annotrack/_dock_widgets.py
+++ b/src/annotrack/_dock_widgets.py
@@ -11,7 +11,7 @@ from typing import Tuple, Union
 
 
 @magic_factory(
-    path_to_csv={'widget_type': 'FileEdit'}, 
+    path_to_csv={'widget_type': 'FileEdit', 'mode': 'r'},
     output_dir={'widget_type': 'FileEdit', 'mode' : 'd'}, 
     tzyx_cols={'widget_type' : 'LiteralEvalLineEdit'},
     scale={'widget_type' : 'LiteralEvalLineEdit'},

--- a/src/annotrack/_dock_widgets.py
+++ b/src/annotrack/_dock_widgets.py
@@ -17,9 +17,9 @@ from typing import Tuple, Union
     scale={'widget_type' : 'LiteralEvalLineEdit'},
 )
 def sample_from_csv(
-    napari_viewer : napari.Viewer, 
-    path_to_csv: str, 
-    output_dir: str, 
+    napari_viewer : napari.Viewer,
+    path_to_csv: Path,
+    output_dir: Path,
     output_name: str,
     category_col: str = 'sample_type', 
     n_samples = 30,

--- a/src/annotrack/annotation.py
+++ b/src/annotrack/annotation.py
@@ -145,8 +145,10 @@ class SampleViewer:
         self.v_source = 'self'
         if viewer is not None:
             message = (
-            """Mark samples as correct or incorrect by pressing y or n,
-            respectively.
+            """
+            Mark samples as correct or incorrect by pressing y or n,
+            respectively. *This will advance to the next sample.* Read below
+            for how to mark specific error types.
             
             To indicate that an ID swap has occurred, navigate to the first
             frame of the new track and press i.
@@ -164,7 +166,7 @@ class SampleViewer:
             previous sample.
             """
             )
-            print(m)
+            print(message)
             self.v_source = 'preexising'
 
         # this lil' guys not hurting anything... or helping... so sue me
@@ -251,29 +253,31 @@ class SampleViewer:
         # initialise the viewer if it doesnt exist
         if self.v is None:
             self.v = napari.Viewer()
-            print('---------------------------------------------------------')
             print(f"Showing sample 1/{len(self.samples_list)}")
             print('---------------------------------------------------------')
-            m = 'Mark samples as correct or incorrect by pressing y or n, \n'
-            m = m + 'repspectively. \n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'To indicate that an ID swap has has occured, at a given \n'
-            m = m + 'point in time press i.\n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'To indicate that a false termination or start has occured\n'
-            m = m + 'at a given point in time, use t or Shift-t, respectively.\n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'To indicate that a tracking error at a given time point\n'
-            m = m + 'is associated with a segmentation error, press s.\n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'Pressing i, t or Shift-t will record the frame number at\n'
-            m = m + 'which the error occured. This will be saved into the \n'
-            m = m + 'info csv in the sample.smpl directory\n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'To navagate to the next sample, use 2. To move to the \n'
-            m = m + 'previous sample, use 1. (a keyboard agnostic approach)\n'
-            m = m + '---------------------------------------------------------\n'
-            print(m)
+            message = (
+                """
+                Mark samples as correct or incorrect by pressing y or n,
+                respectively. *This will advance to the next sample.* Read
+                below for how to mark specific error types.
+    
+                To indicate that an ID swap has occurred, navigate to the first
+                frame of the new track and press i.
+    
+                To indicate that a false termination or start has occurred,
+                navigate to the frame where it occurs and press t or Shift-t.
+    
+                To indicate that a tracking error (any of the above) is caused
+                by a segmentation error, press s.
+    
+                These error types will be saved to the info.csv file in the
+                sample.smpl directory.
+    
+                To navigate to the next sample, use 2, and use 1 to navigate to
+                the previous sample.
+                """
+            )
+            print(message)
         # get the names of layers currently attached to the viewer
         layer_names = [l.name for l in self.v.layers]
         prop = {}
@@ -420,7 +424,7 @@ class SampleViewer:
             print('---------------------------------------------------------')
             print(f"Showing sample {self._i + 1}/{len(self.samples_list)}")
             self._check_ann_status()
-            print("To navagate to prior samples press the 1 key")
+            print("To navigate to prior samples press the 1 key")
 
     
     def _previous(self):
@@ -433,7 +437,7 @@ class SampleViewer:
             print('---------------------------------------------------------')
             print(f"Showing sample {self._i + 1}/{len(self.samples_list)}")
             self._check_ann_status()
-            print("To navagate to the next sample press the 2 key")
+            print("To navigate to the next sample press the 2 key")
 
 
     def _annotate(self, ann):

--- a/src/annotrack/annotation.py
+++ b/src/annotrack/annotation.py
@@ -144,25 +144,26 @@ class SampleViewer:
         self.v = viewer
         self.v_source = 'self'
         if viewer is not None:
-            m = 'Mark samples as correct or incorrect by pressing y or n, \n'
-            m = m + 'repspectively. \n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'To indicate that an ID swap has has occured, at a given \n'
-            m = m + 'point in time press i.\n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'To indicate that a false termination or start has occured\n'
-            m = m + 'at a given point in time, use t or Shift-t, respectively.\n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'To indicate that a tracking error at a given time point\n'
-            m = m + 'is associated with a segmentation error, press s.\n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'Pressing i, t or Shift-t will record the frame number at\n'
-            m = m + 'which the error occured. This will be saved into the \n'
-            m = m + 'info csv in the sample.smpl directory\n'
-            m = m + '---------------------------------------------------------\n'
-            m = m + 'To navagate to the next sample, use 2. To move to the \n'
-            m = m + 'previous sample, use 1. (a keyboard agnostic approach)\n'
-            m = m + '---------------------------------------------------------\n'
+            message = (
+            """Mark samples as correct or incorrect by pressing y or n,
+            respectively.
+            
+            To indicate that an ID swap has occurred, navigate to the first
+            frame of the new track and press i.
+            
+            To indicate that a false termination or start has occurred,
+            navigate to the frame where it occurs and press t or Shift-t.
+            
+            To indicate that a tracking error (any of the above) is caused by
+            a segmentation error, press s.
+            
+            These error types will be saved to the info.csv file in the
+            sample.smpl directory.
+            
+            To navigate to the next sample, use 2, and use 1 to navigate to the
+            previous sample.
+            """
+            )
             print(m)
             self.v_source = 'preexising'
 

--- a/src/annotrack/annotation.py
+++ b/src/annotrack/annotation.py
@@ -73,7 +73,7 @@ class SampleViewer:
                         'array_order' : (<col name corresponding to coords>, ...)
                         'time_col' : str, 
                         'id_col' : str
-                }
+                        }
                     (ID, t) : {
                         'df' : pd.DataFrame,
                         'df_path' : 'path/to/info/df.csv', 

--- a/src/annotrack/sampling.py
+++ b/src/annotrack/sampling.py
@@ -926,18 +926,18 @@ def _guess_channel_axis(shp):
 
 
 def open_with_correct_modality(image_path, channel=None, chan_axis=None):
-    if chan_axis is None:
-        chan_axis = _guess_channel_axis(image.shape)
     suffix = Path(image_path).suffix
     if suffix == '.zarr':
         image = zarr.open(image_path, 'r')
         if isinstance(image, zarr.hierarchy.Group):  # assume ome-zarr
-            image = zarr['/0']
+            image = image['/0']
             if not isinstance(image, zarr.core.Array):
                 raise ValueError(
                         'Not a zarr array or ome zarr array: {image_path}'
                         )
 
+        if chan_axis is None:
+            chan_axis = _guess_channel_axis(image.shape)
         if channel is not None and chan_axis is not None:
             # extract only the desired channel
             image = da.array(image)
@@ -1007,7 +1007,7 @@ def get_sample_hypervolumes(sample, img_channel=None):
             slice_.append(s_)
         img = np.asarray(image[tuple(slice_)])
         if labels is not None:
-            lab = np.asarray(tuple(slice_))
+            lab = np.asarray(labels[tuple(slice_)])
         else:
             lab = None
         sample[pair]['image'] = img

--- a/src/annotrack/sampling.py
+++ b/src/annotrack/sampling.py
@@ -493,9 +493,6 @@ def sample_tracks(tracks_path: str,
         df = pd.read_parquet(tracks_path)
     else:
         raise ValueError('please ensure the tracks file is a csv or parquet')
-    #print(tracks_path)
-    #print(image_path)
-    #print(labels_path)
     # calculate weights if required
     coords_cols = _coords_cols(array_order, non_tzyx_col, time_col)
     # well this was lazy (see below)

--- a/src/annotrack/sampling.py
+++ b/src/annotrack/sampling.py
@@ -997,9 +997,6 @@ def get_sample_hypervolumes(sample, img_channel=None):
         labels = None
     array_order = sample['coord_info']['array_order']
     pairs = [key for key in sample.keys() if isinstance(key, tuple)]
-    #if labels is not None:
-        #print(labels.shape)
-        #labels = np.array(labels)
     for pair in pairs:
         l = len(array_order)
         m = f'Image must be of same dimensions ({l}) as in the sample array_order: {array_order}'
@@ -1008,15 +1005,9 @@ def get_sample_hypervolumes(sample, img_channel=None):
         for key in array_order:
             s_ = sample[pair]['b_box'][key]
             slice_.append(s_)
-        #print(slice_)
-        #print(image)
-        img = image[tuple(slice_)]
-        if isinstance(img, da.core.Array):
-            img = img.compute()
+        img = np.asarray(image[tuple(slice_)])
         if labels is not None:
-            lab = labels[tuple(slice_)]
-            if isinstance(lab, da.core.Array):
-                lab = img.compute()
+            lab = np.asarray(tuple(slice_))
         else:
             lab = None
         sample[pair]['image'] = img


### PR DESCRIPTION
- Remove print comments
- Make message a multiline string
- Align curly braces in docstring
- Remove redundant import
- Use mode='r' for FileEdit widget
- Annotate paths as Path
- Typos
- Annotate fileedit as mode='r'
- Tweak opening code to support ome-zarrs
- Tweak messages
- Simplify image slicing code
- Fix introduced bugs in reading
- Don’t overwrite initial sample file (!)
- Add script to debug annotrack
